### PR TITLE
TcpConnector's close method didn't call 'destroy' on socket

### DIFF
--- a/lib/src/tcp_connector.dart
+++ b/lib/src/tcp_connector.dart
@@ -31,7 +31,7 @@ class TcpConnector extends ModbusConnector {
 
   @override
   Future<void> close() {
-    return _socket.close();
+    return _socket.close().then((sock) => sock.destroy());
   }
 
   void _onData(List<int> tcpData) {


### PR DESCRIPTION
TcpConnector's 'close' method didn't call 'close' method on the underlying socket.
Accoring to the [this](https://api.dartlang.org/stable/2.7.0/dart-io/Socket/close.html) and [this](https://api.dartlang.org/stable/2.7.0/dart-io/Socket/destroy.html) 'close' method only closes outgoing stream. It leads to always running application (for example Example/main.dart), because application is waiting for asynchronous reading operation.


Also, I think it is better to flush the outgoing channel when socket is closing.