### PR TITLE
Fix string error in _onConnectorError

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -40,7 +40,7 @@ class ModbusClientImpl extends ModbusClient {
 
   void _onConnectorError(error, stackTrace) {
     _completer?.completeError(error, stackTrace);
-    throw ModbusConnectException("Connector Error: " + error);
+    throw ModbusConnectException("Connector Error: ${error}");
   }
 
   void _onConnectorClose() {


### PR DESCRIPTION
Minor bug - string error was masking the actual exception message. 