### PR TITLE
Added callback to catch an error happening on the socket connection

### DIFF
--- a/lib/modbus.dart
+++ b/lib/modbus.dart
@@ -99,8 +99,9 @@ ModbusClient createTcpClient(address,
           int port = 502,
           ModbusMode mode = ModbusMode.rtu,
           int unitId = 1,
-          Duration? timeout,
+          Duration? connectionTimeout,
+          Duration? requestTimeout,
           Function(dynamic error, dynamic stackTrace)? onConnectionError
         }) =>
     ModbusClientImpl(
-        TcpConnector(address, port, mode, timeout: timeout), unitId, onConnectionError: onConnectionError);
+        TcpConnector(address, port, mode, timeout: connectionTimeout), unitId, onConnectionError: onConnectionError, requestTimeout: requestTimeout);

--- a/lib/modbus.dart
+++ b/lib/modbus.dart
@@ -95,9 +95,12 @@ ModbusClient createClient(TcpConnector connector, {int unitId = 1}) =>
     ModbusClientImpl(connector, unitId);
 
 ModbusClient createTcpClient(address,
-        {int port = 502,
-        ModbusMode mode = ModbusMode.rtu,
-        int unitId = 1,
-        Duration? timeout}) =>
+        {
+          int port = 502,
+          ModbusMode mode = ModbusMode.rtu,
+          int unitId = 1,
+          Duration? timeout,
+          Function(dynamic error, dynamic stackTrace)? onConnectionError
+        }) =>
     ModbusClientImpl(
-        TcpConnector(address, port, mode, timeout: timeout), unitId);
+        TcpConnector(address, port, mode, timeout: timeout), unitId, onConnectionError: onConnectionError);

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -20,13 +20,15 @@ class ModbusClientImpl extends ModbusClient {
   Map<PendingKey, PendingCallback> _pendingMap = HashMap();
   Map<PendingKey, Completer> _waitingMap = HashMap();
   Queue<Request> _waitingQueue = DoubleLinkedQueue();
+  Duration? _requestTimeout;
   Function(dynamic error, dynamic stackTrace)? _onConnectionError;
 
-  ModbusClientImpl(this._connector, int unitId, { Function(dynamic error, dynamic stackTrace)? onConnectionError }) {
+  ModbusClientImpl(this._connector, int unitId, { Function(dynamic error, dynamic stackTrace)? onConnectionError, Duration? requestTimeout = const Duration(milliseconds: 6000) }) {
     _connector.onResponse = _onConnectorData;
     _connector.onError = _onConnectorError;
     _connector.onClose = _onConnectorClose;
     _onConnectionError = onConnectionError;
+    _requestTimeout = requestTimeout;
     _connector.setUnitId(unitId);
   }
 
@@ -174,7 +176,8 @@ class ModbusClientImpl extends ModbusClient {
       } else {
         completer!.complete(responseData);
       }
-    });
+    })
+    .timeout(_requestTimeout!);
   }
 
   @override

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -20,11 +20,13 @@ class ModbusClientImpl extends ModbusClient {
   Map<PendingKey, PendingCallback> _pendingMap = HashMap();
   Map<PendingKey, Completer> _waitingMap = HashMap();
   Queue<Request> _waitingQueue = DoubleLinkedQueue();
+  Function(dynamic error, dynamic stackTrace)? _onConnectionError;
 
-  ModbusClientImpl(this._connector, int unitId) {
+  ModbusClientImpl(this._connector, int unitId, { Function(dynamic error, dynamic stackTrace)? onConnectionError }) {
     _connector.onResponse = _onConnectorData;
     _connector.onError = _onConnectorError;
     _connector.onClose = _onConnectorClose;
+    _onConnectionError = onConnectionError;
     _connector.setUnitId(unitId);
   }
 
@@ -67,6 +69,7 @@ class ModbusClientImpl extends ModbusClient {
     _pendingMap.clear();
     _waitingMap.clear();
     // _completer?.completeError(error, stackTrace);
+    if(_onConnectionError != null) _onConnectionError!(error, stackTrace);
     throw ModbusConnectException("Connector Error: ${error}");
   }
 


### PR DESCRIPTION
I was having a problem where, whenever I physically disconnected the device connected through the modbus protocol, I'd see an exception on the console but all subsequent petitions I had on a timer never returned thus never received any actual errors on my code and I couldn't recreate the connection.

This solves the issue by adding a callback right where the error is thrown so the user knows it happened and act accordingly.

